### PR TITLE
Add renderOverNavigationBar attribute, which renders the showcase over the nav bar.

### DIFF
--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -61,6 +61,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     private int mContentTopMargin;
     private boolean mDismissOnTouch = false;
     private boolean mShouldRender = false; // flag to decide when we should actually render
+    private boolean mRenderOverNav = false;
     private int mMaskColour;
     private AnimationFactory mAnimationFactory;
     private boolean mShouldAnimate = true;
@@ -256,7 +257,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
             /**
              * If we're on lollipop then make sure we don't draw over the nav bar
              */
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (!mRenderOverNav && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 mBottomMargin = getSoftButtonsBarSizePort((Activity) getContext());
                 FrameLayout.LayoutParams contentLP = (LayoutParams) getLayoutParams();
 
@@ -420,6 +421,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
         setMaskColour(config.getMaskColor());
         setShape(config.getShape());
         setShapePadding(config.getShapePadding());
+        setRenderOverNavigationBar(config.getRenderOverNavigationBar());
     }
 
     private void updateDismissButton() {
@@ -574,6 +576,12 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
         public Builder withRectangleShape(boolean fullWidth) {
             this.shapeType = RECTANGLE_SHAPE;
             this.fullWidth = fullWidth;
+            return this;
+        }
+
+        public Builder renderOverNavigationBar() {
+            // Note: This only has an effect in Lollipop or above.
+            showcaseView.setRenderOverNavigationBar(true);
             return this;
         }
 
@@ -760,4 +768,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
         return 0;
     }
 
+    private void setRenderOverNavigationBar(boolean mRenderOverNav) {
+        this.mRenderOverNav = mRenderOverNav;
+    }
 }

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/ShowcaseConfig.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/ShowcaseConfig.java
@@ -21,6 +21,7 @@ public class ShowcaseConfig {
     private long mFadeDuration = DEFAULT_FADE_TIME;
     private Shape mShape = DEFAULT_SHAPE;
     private int mShapePadding = DEFAULT_SHAPE_PADDING;
+    private boolean renderOverNav = false;
 
     public ShowcaseConfig() {
         mMaskColour = Color.parseColor(ShowcaseConfig.DEFAULT_MASK_COLOUR);
@@ -82,5 +83,13 @@ public class ShowcaseConfig {
 
     public int getShapePadding() {
         return mShapePadding;
+    }
+
+    public boolean getRenderOverNavigationBar() {
+        return renderOverNav;
+    }
+
+    public void setRenderOverNavigationBar(boolean renderOverNav) {
+        this.renderOverNav = renderOverNav;
     }
 }


### PR DESCRIPTION
I added a renderOverNavigationBar method to Builder. This'll set the ShowcaseView to render over the navigation bar (if it exists) in Lollipop and above. This fixes #41, #33, and #20, which all deal with using this library for full screen Activities.