### PR TITLE
Several null checks added to mListeners usage in MaterialShowcaseView

### DIFF
--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -205,9 +205,12 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
 
 
     private void notifyOnDisplayed() {
-        for (IShowcaseListener listener : mListeners) {
-            listener.onShowcaseDisplayed(this);
-        }
+
+		if(mListeners != null){
+			for (IShowcaseListener listener : mListeners) {
+				listener.onShowcaseDisplayed(this);
+			}
+		}
     }
 
     private void notifyOnDismissed() {
@@ -390,13 +393,16 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     }
 
     public void addShowcaseListener(IShowcaseListener showcaseListener) {
-        mListeners.add(showcaseListener);
+
+		if(mListeners != null)
+			mListeners.add(showcaseListener);
     }
 
     public void removeShowcaseListener(MaterialShowcaseSequence showcaseListener) {
-        if (mListeners.contains(showcaseListener)) {
-            mListeners.remove(showcaseListener);
-        }
+
+		if ((mListeners != null) && mListeners.contains(showcaseListener)) {
+			mListeners.remove(showcaseListener);
+		}
     }
 
     void setDetachedListener(IDetachedListener detachedListener) {


### PR DESCRIPTION
Several null checks added to mListeners in MaterialShowcaseView to prevent NPEs if mListeners is not yet initialised (fix for https://github.com/deano2390/MaterialShowcaseView/issues/69 ). 