### PR TITLE
Do not set content text alpha when sets the title

### DIFF
--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -356,8 +356,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     }
 
     private void setTitleText(CharSequence contentText) {
-        if (mTitleTextView != null && !contentText.equals("")) {
-            mContentTextView.setAlpha(0.5F);
+        if (mTitleTextView != null) {
             mTitleTextView.setText(contentText);
         }
     }


### PR DESCRIPTION
````
private void setTitleText(CharSequence contentText) {
    if(this.mTitleTextView != null && !contentText.equals("")) {
        // THIS LINE SHOULD NOT EXIST
        this.mContentTextView.setAlpha(0.5F);
        this.mTitleTextView.setText(contentText);
    }
}
````
Why this code sets the mContextTextView alpha to 0.5?
````
MaterialShowcaseView.Builder builder = new MaterialShowcaseView.Builder(activity);
builder.setTarget(view);
builder.setTitleText(titleResource);
builder.setContentText(detailResource);
builder.setContentTextColor(android.R.color.white);
builder.setDismissText(R.string.showcase_got_it);
builder.setDismissOnTouch(false);
builder.setDelay(Constants.SHOWCASE_SHOW_DELAY);
builder.setMaskColour(ContextCompat.getColor(activity, R.color.primary_showcase));
builder.singleUse(singleUseId);
````
Setting the content text color does not solve the problem...