### PR TITLE
Added option to use circular reveal for API >= 21.

### DIFF
--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/CircularRevealAnimationFactory.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/CircularRevealAnimationFactory.java
@@ -1,0 +1,95 @@
+package uk.co.deanwild.materialshowcaseview;
+
+import android.animation.Animator;
+import android.animation.AnimatorSet;
+import android.animation.ObjectAnimator;
+import android.annotation.TargetApi;
+import android.graphics.Point;
+import android.os.Build;
+import android.view.View;
+import android.view.ViewAnimationUtils;
+import android.view.animation.AccelerateDecelerateInterpolator;
+
+
+public class CircularRevealAnimationFactory implements IAnimationFactory {
+
+    private static final String ALPHA = "alpha";
+    private static final float INVISIBLE = 0f;
+    private static final float VISIBLE = 1f;
+
+    private final AccelerateDecelerateInterpolator interpolator;
+
+    public CircularRevealAnimationFactory() {
+        interpolator = new AccelerateDecelerateInterpolator();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void animateInView(View target, Point point, long duration, final AnimationStartListener listener) {
+        Animator animator = ViewAnimationUtils.createCircularReveal(target, point.x, point.y, 0,
+                target.getWidth() > target.getHeight() ? target.getWidth() : target.getHeight());
+        animator.setDuration(duration).addListener(new Animator.AnimatorListener() {
+            @Override
+            public void onAnimationStart(Animator animation) {
+                listener.onAnimationStart();
+            }
+
+            @Override
+            public void onAnimationEnd(Animator animation) {
+
+            }
+
+            @Override
+            public void onAnimationCancel(Animator animation) {
+
+            }
+
+            @Override
+            public void onAnimationRepeat(Animator animation) {
+
+            }
+        });
+
+        animator.start();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    public void animateOutView(View target, Point point, long duration, final AnimationEndListener listener) {
+        Animator animator = ViewAnimationUtils.createCircularReveal(target, point.x, point.y,
+                target.getWidth() > target.getHeight() ? target.getWidth() : target.getHeight(), 0);
+        animator.setDuration(duration).addListener(new Animator.AnimatorListener() {
+            @Override
+            public void onAnimationStart(Animator animation) {
+
+            }
+
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                listener.onAnimationEnd();
+            }
+
+            @Override
+            public void onAnimationCancel(Animator animation) {
+
+            }
+
+            @Override
+            public void onAnimationRepeat(Animator animation) {
+
+            }
+        });
+
+        animator.start();
+    }
+
+    @Override
+    public void animateTargetToPoint(MaterialShowcaseView showcaseView, Point point) {
+        AnimatorSet set = new AnimatorSet();
+        ObjectAnimator xAnimator = ObjectAnimator.ofInt(showcaseView, "showcaseX", point.x);
+        ObjectAnimator yAnimator = ObjectAnimator.ofInt(showcaseView, "showcaseY", point.y);
+        set.playTogether(xAnimator, yAnimator);
+        set.setInterpolator(interpolator);
+        set.start();
+    }
+}

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/FadeAnimationFactory.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/FadeAnimationFactory.java
@@ -3,12 +3,15 @@ package uk.co.deanwild.materialshowcaseview;
 import android.animation.Animator;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.annotation.TargetApi;
 import android.graphics.Point;
+import android.os.Build;
 import android.view.View;
+import android.view.ViewAnimationUtils;
 import android.view.animation.AccelerateDecelerateInterpolator;
 
 
-public class AnimationFactory implements IAnimationFactory{
+public class FadeAnimationFactory implements IAnimationFactory{
 
     private static final String ALPHA = "alpha";
     private static final float INVISIBLE = 0f;
@@ -16,12 +19,12 @@ public class AnimationFactory implements IAnimationFactory{
 
     private final AccelerateDecelerateInterpolator interpolator;
 
-    public AnimationFactory() {
+    public FadeAnimationFactory() {
         interpolator = new AccelerateDecelerateInterpolator();
     }
 
     @Override
-    public void fadeInView(View target, long duration, final AnimationStartListener listener) {
+    public void animateInView(View target, Point point, long duration, final AnimationStartListener listener) {
         ObjectAnimator oa = ObjectAnimator.ofFloat(target, ALPHA, INVISIBLE, VISIBLE);
         oa.setDuration(duration).addListener(new Animator.AnimatorListener() {
             @Override
@@ -45,7 +48,7 @@ public class AnimationFactory implements IAnimationFactory{
     }
 
     @Override
-    public void fadeOutView(View target, long duration, final AnimationEndListener listener) {
+    public void animateOutView(View target, Point point, long duration, final AnimationEndListener listener) {
         ObjectAnimator oa = ObjectAnimator.ofFloat(target, ALPHA, INVISIBLE);
         oa.setDuration(duration).addListener(new Animator.AnimatorListener() {
             @Override

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/IAnimationFactory.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/IAnimationFactory.java
@@ -6,9 +6,9 @@ import android.view.View;
 
 public interface IAnimationFactory {
 
-    void fadeInView(View target, long duration, AnimationStartListener listener);
+    void animateInView(View target, Point point, long duration, AnimationStartListener listener);
 
-    void fadeOutView(View target, long duration, AnimationEndListener listener);
+    void animateOutView(View target, Point point, long duration, AnimationEndListener listener);
 
     void animateTargetToPoint(MaterialShowcaseView showcaseView, Point point);
 

--- a/sample/src/main/java/uk/co/deanwild/materialshowcaseviewsample/SimpleSingleExample.java
+++ b/sample/src/main/java/uk/co/deanwild/materialshowcaseviewsample/SimpleSingleExample.java
@@ -53,6 +53,7 @@ public class SimpleSingleExample extends AppCompatActivity implements View.OnCli
                 .setContentText("This is some amazing feature you should know about")
                 .setDelay(withDelay) // optional but starting animations immediately in onCreate can make them choppy
                 .singleUse(SHOWCASE_ID) // provide a unique ID used to ensure it is only shown once
+//                .useFadeAnimation() // remove comment if you want to use fade animations for Lollipop & up
                 .show();
     }
 


### PR DESCRIPTION
Hi, I added an option to use the new circular reveal to give the showcase a more "material" feel on Lollipop and above devices.  Had to make minor tweaks to the IAnimationFactory and builder.