### PR TITLE
Made bottom margin for Navigation Bar optional 

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 12
         targetSdkVersion 28
-        versionCode 2
-        versionName "1.3.5"
+        versionCode 1
+        versionName "1.0"
     }
     buildTypes {
         release {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 12
         targetSdkVersion 28
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.3.5"
     }
     buildTypes {
         release {

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -65,7 +65,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     private TextView mContentTextView;
     private TextView mDismissButton;
     private boolean mHasCustomGravity;
-    private boolean mHasNavigationMargin = true;
+    private boolean mHasNavigationMargin = false;
     private TextView mSkipButton;
     private int mGravity;
     private int mContentBottomMargin;

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -65,6 +65,7 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     private TextView mContentTextView;
     private TextView mDismissButton;
     private boolean mHasCustomGravity;
+    private boolean mHasNavigationMargin = true;
     private TextView mSkipButton;
     private int mGravity;
     private int mContentBottomMargin;
@@ -290,6 +291,16 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     }
 
     /**
+     * Used for setting height for Canvas onDraw().
+     *
+     * @param bottomMargin true if set margin for bottom navigation bar
+     *                     false if don't set margin for bottom navigation bar
+     */
+    public void setBottomNavigationMargin(boolean bottomMargin) {
+        mHasNavigationMargin = bottomMargin;
+    }
+
+    /**
      * Tells us about the "Target" which is the view we want to anchor to.
      * We figure out where it is on screen and (optionally) how big it is.
      * We also figure out whether to place our content and dismiss button above or below it.
@@ -310,7 +321,10 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
             if (!mRenderOverNav && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
 
 
-                mBottomMargin = getSoftButtonsBarSizePort();
+                if (mHasNavigationMargin)
+                    mBottomMargin = getSoftButtonsBarSizePort();
+                else
+                    mBottomMargin = 0;
 
 
                 FrameLayout.LayoutParams contentLP = (LayoutParams) getLayoutParams();
@@ -563,40 +577,40 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
      */
     public void setConfig(ShowcaseConfig config) {
 
-        if(config.getDelay() > -1){
+        if (config.getDelay() > -1) {
             setDelay(config.getDelay());
         }
 
-        if(config.getFadeDuration() > 0){
+        if (config.getFadeDuration() > 0) {
             setFadeDuration(config.getFadeDuration());
         }
 
 
-        if(config.getContentTextColor() > 0){
+        if (config.getContentTextColor() > 0) {
             setContentTextColor(config.getContentTextColor());
         }
 
-        if(config.getDismissTextColor() > 0){
+        if (config.getDismissTextColor() > 0) {
             setDismissTextColor(config.getDismissTextColor());
         }
 
-        if(config.getDismissTextStyle() != null){
+        if (config.getDismissTextStyle() != null) {
             setDismissStyle(config.getDismissTextStyle());
         }
 
-        if(config.getMaskColor() > 0){
+        if (config.getMaskColor() > 0) {
             setMaskColour(config.getMaskColor());
         }
 
-        if(config.getShape() != null){
+        if (config.getShape() != null) {
             setShape(config.getShape());
         }
 
-        if(config.getShapePadding() > -1){
+        if (config.getShapePadding() > -1) {
             setShapePadding(config.getShapePadding());
         }
 
-        if(config.getRenderOverNavigationBar() != null){
+        if (config.getRenderOverNavigationBar() != null) {
             setRenderOverNavigationBar(config.getRenderOverNavigationBar());
         }
     }
@@ -667,6 +681,17 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
          */
         public Builder setGravity(int gravity) {
             showcaseView.setGravity(gravity);
+            return this;
+        }
+
+        /**
+         * Builder method for setting margin for bottom navigation bar
+         *
+         * @param hasBottomMargin true if set margin for bottom navigation bar
+         *                        false if don't set margin for bottom navigation bar
+         */
+        public Builder setBottomNavigationMargin(boolean hasBottomMargin) {
+            showcaseView.setBottomNavigationMargin(hasBottomMargin);
             return this;
         }
 
@@ -1046,13 +1071,13 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
     public void fadeIn() {
         setVisibility(INVISIBLE);
         mAnimationFactory.animateInView(this, mTarget.getPoint(), mFadeDurationInMillis,
-                new IAnimationFactory.AnimationStartListener() {
-                    @Override
-                    public void onAnimationStart() {
-                        setVisibility(View.VISIBLE);
-                        notifyOnDisplayed();
-                    }
+            new IAnimationFactory.AnimationStartListener() {
+                @Override
+                public void onAnimationStart() {
+                    setVisibility(View.VISIBLE);
+                    notifyOnDisplayed();
                 }
+            }
         );
     }
 


### PR DESCRIPTION
It should be optional to get bottom margin for Navigation bar especially when the app uses full-screen mode with hiding Navigation bar.

![Screenshot_20190807-183812](https://user-images.githubusercontent.com/5780664/62807881-71a01000-baab-11e9-9cee-3354b67899bf.png)
