### PR TITLE
Fixed the Exception java.lang.IllegalStateException: Cannot start this animator on a detached view!

### DIFF
--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/CircularRevealAnimationFactory.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/CircularRevealAnimationFactory.java
@@ -26,6 +26,10 @@ public class CircularRevealAnimationFactory implements IAnimationFactory {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public void animateInView(View target, Point point, long duration, final AnimationStartListener listener) {
+        if (!isAttachedToWindow(target)) {
+            listener.onAnimationStart();
+            return;
+        }
         Animator animator = ViewAnimationUtils.createCircularReveal(target, point.x, point.y, 0,
                 target.getWidth() > target.getHeight() ? target.getWidth() : target.getHeight());
         animator.setDuration(duration).addListener(new Animator.AnimatorListener() {
@@ -56,6 +60,10 @@ public class CircularRevealAnimationFactory implements IAnimationFactory {
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Override
     public void animateOutView(View target, Point point, long duration, final AnimationEndListener listener) {
+        if (!isAttachedToWindow(target)) {
+            listener.onAnimationEnd();
+            return;
+        }
         Animator animator = ViewAnimationUtils.createCircularReveal(target, point.x, point.y,
                 target.getWidth() > target.getHeight() ? target.getWidth() : target.getHeight(), 0);
         animator.setDuration(duration).addListener(new Animator.AnimatorListener() {
@@ -81,6 +89,13 @@ public class CircularRevealAnimationFactory implements IAnimationFactory {
         });
 
         animator.start();
+    }
+
+    private boolean isAttachedToWindow(View target) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            return target.isAttachedToWindow();
+        }
+        return target.getWindowToken() != null;
     }
 
     @Override

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/FadeAnimationFactory.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/FadeAnimationFactory.java
@@ -25,6 +25,10 @@ public class FadeAnimationFactory implements IAnimationFactory{
 
     @Override
     public void animateInView(View target, Point point, long duration, final AnimationStartListener listener) {
+        if (!isAttachedToWindow(target)) {
+            listener.onAnimationStart();
+            return;
+        }
         ObjectAnimator oa = ObjectAnimator.ofFloat(target, ALPHA, INVISIBLE, VISIBLE);
         oa.setDuration(duration).addListener(new Animator.AnimatorListener() {
             @Override
@@ -49,6 +53,10 @@ public class FadeAnimationFactory implements IAnimationFactory{
 
     @Override
     public void animateOutView(View target, Point point, long duration, final AnimationEndListener listener) {
+        if (!isAttachedToWindow(target)) {
+            listener.onAnimationEnd();
+            return;
+        }
         ObjectAnimator oa = ObjectAnimator.ofFloat(target, ALPHA, INVISIBLE);
         oa.setDuration(duration).addListener(new Animator.AnimatorListener() {
             @Override
@@ -69,6 +77,13 @@ public class FadeAnimationFactory implements IAnimationFactory{
             }
         });
         oa.start();
+    }
+
+    private boolean isAttachedToWindow(View target) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            return target.isAttachedToWindow();
+        }
+        return target.getWindowToken() != null;
     }
 
     @Override

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -1054,6 +1054,11 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
 
     public void animateOut() {
 
+        if (mAnimationFactory == null || mTarget == null) {
+            removeFromWindow();
+            return;
+        }
+
         mAnimationFactory.animateOutView(this, mTarget.getPoint(), mFadeDurationInMillis, new IAnimationFactory.AnimationEndListener() {
             @Override
             public void onAnimationEnd() {

--- a/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
+++ b/library/src/main/java/uk/co/deanwild/materialshowcaseview/MaterialShowcaseView.java
@@ -992,6 +992,9 @@ public class MaterialShowcaseView extends FrameLayout implements View.OnTouchLis
                 } else {
                     attached = getWindowToken() != null;
                 }
+                if (attached && mTarget != null) {
+                    setTarget(mTarget);
+                }
                 if (mShouldAnimate && attached) {
                     fadeIn();
                 } else {


### PR DESCRIPTION
The previous fix #172 only works for fadeIn(), but not animateOut().
Apps were still crashing. Fixed it now.
(Don't judge me for using Codex. It was much faster and the result speaks for itself.)